### PR TITLE
Update AWS OpenSearch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Package `requests_aws4auth` is required to connect to the AWS OpenSearch service
 import boto3
 from opensearch_logger import OpenSearchHandler
 from requests_aws4auth import AWS4Auth
+from opensearchpy import RequestsHttpConnection
 
 host = ""  # The OpenSearch domain endpoint starting with https://
 region = "us-east-1"  # AWS Region
@@ -178,6 +179,7 @@ handler = OpenSearchHandler(
     verify_certs=True,
     ssl_assert_hostname=True,
     ssl_show_warn=True,
+    connection_class=RequestsHttpConnection,
 )
 ```
 


### PR DESCRIPTION
OpenSearch requires a connection_class parameter when using AWS4Auth as an authentication class.

Credit to this Stackoverflow poster: https://stackoverflow.com/a/69527773

This may also apply to the Kerberos authentication example but I am unable to test it.